### PR TITLE
Feature/17/update block time

### DIFF
--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -51,7 +51,7 @@ pub mod time {
 	/// `SLOT_DURATION` should have the same value.
 	///
 	/// <https://research.web3.foundation/en/latest/polkadot/block-production/Babe.html#-6.-practical-results>
-	pub const MILLISECS_PER_BLOCK: Moment = 12000;
+	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
 
 	// NOTE: Currently it is not possible to change the slot duration after the chain has started.

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -180,12 +180,12 @@ mod multiplier_tests {
 	#[test]
 	fn min_change_per_day() {
 		run_with_system_weight(max_normal(), || {
-			let expected = Multiplier::saturating_from_rational(1054, 1000);
+			let expected = Multiplier::saturating_from_rational(1108, 1000);
 			let mut fm = Multiplier::one();
 			// See the example in the doc of `TargetedFeeAdjustment`. are at least 0.234, hence
 			// `fm > 1.234`.
-			// For 12 seconds per block, we have 7200 blocks in a day
-			// then instead, fm >= 0.00001 * 7200 * 0.75 fm >= 0.054
+			// For 6 seconds per block, we have 14400 blocks in a day
+			// then instead, fm >= 0.00001 * 14400 * 0.75 fm >= 0.108
 			for _ in 0..DAYS {
 				let next = runtime_multiplier_update(fm);
 				fm = next;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -514,7 +514,8 @@ pallet_staking_reward_curve::build! {
 }
 
 parameter_types! {
-	pub const SessionsPerEra: sp_staking::SessionIndex = 24;
+	/// An era in 24 hours (6 * epoch)
+	pub const SessionsPerEra: sp_staking::SessionIndex = 6;
 	pub const BondingDuration: sp_staking::EraIndex = 3;
 	pub const SlashDeferDuration: sp_staking::EraIndex = 1; // 1/4 the bonding duration.
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;


### PR DESCRIPTION
This PR is rebased on the #4. When #4 will be merged, only the last commit well be in this PR. Should merge #4 before this one.

Like said in the YouTrack ticket, I haven't found any `era` settings, so `block` is well 6 seconds and `epoch` 4h.