### PR TITLE
Optimize docker build, pin rust version, use  debian for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 # This is the first stage. Here we install all the dependencies that we need in order to build the Allfeat binary
 # and we create the Allfeat binary in a rust oriented temporary image.
-FROM rust:slim-buster as builder
-
-ADD . ./workdir
-WORKDIR "/workdir"
+FROM rust:1.76.0-slim-bookworm as builder
 
 # This installs all dependencies that we need (besides Rust).
 RUN apt update -y && \
-    apt install build-essential git clang curl libssl-dev llvm libudev-dev make protobuf-compiler pkg-config -y
+    apt install -y build-essential git clang curl libssl-dev llvm libudev-dev make protobuf-compiler pkg-config
+
+WORKDIR "/workdir"
+COPY . .
 
 # This builds the binary.
 RUN cargo build --locked --release
 
 # This is the 2nd stage: a very small image where we copy the Allfeat binary."
-FROM docker.io/library/ubuntu:20.04
+FROM docker.io/library/debian:bookworm
 
 LABEL io.allfeat.image.type="builder" \
     io.allfeat.image.authors="tech@allfeat.com" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is the first stage. Here we install all the dependencies that we need in order to build the Allfeat binary
 # and we create the Allfeat binary in a rust oriented temporary image.
-FROM rust:1.76.0-slim-bookworm as builder
+FROM rustlang/rust:nightly-bookworm-slim as builder
 
 # This installs all dependencies that we need (besides Rust).
 RUN apt update -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ FROM rust:1.76.0-slim-bookworm as builder
 RUN apt update -y && \
     apt install -y build-essential git clang curl libssl-dev llvm libudev-dev make protobuf-compiler pkg-config
 
-WORKDIR "/workdir"
-COPY . .
+ADD . /workdir
+WORKDIR /workdir
 
 # This builds the binary.
 RUN cargo build --locked --release


### PR DESCRIPTION
This is a short PR based on master to :

- pin rust v1.76 (always better for sustainability)
- use last debian version  (buster LTS will end on july 24)
- use debian for both builder and runtime (symetrical env is even better)
- install debian deps packages before copying app (speedup build time)
