### PR TITLE
Artists major changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5831,6 +5831,7 @@ name = "pallet-artists-v2"
 version = "1.0.0-dev"
 dependencies = [
  "derive-getters",
+ "enumflags2",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/pallets/artists/Cargo.toml
+++ b/pallets/artists/Cargo.toml
@@ -11,7 +11,8 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-log = "0.4.3"
+log = { workspace = true }
+enumflags2 = { workspace = true }
 derive-getters = "0.3.0"
 
 # Substrate

--- a/pallets/artists/src/macros.rs
+++ b/pallets/artists/src/macros.rs
@@ -1,0 +1,70 @@
+// This file is part of Allfeat.
+
+// Copyright (C) 2022-2024 Allfeat.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/// Implements encoding and decoding traits for a wrapper type that represents
+/// bitflags. The wrapper type should contain a field of type `$size`, where
+/// `$size` is an integer type (e.g., u8, u16, u32) that can represent the bitflags.
+/// The `$bitflag_enum` type is the enumeration type that defines the individual bitflags.
+///
+/// This macro provides implementations for the following traits:
+/// - `MaxEncodedLen`: Calculates the maximum encoded length for the wrapper type.
+/// - `Encode`: Encodes the wrapper type using the provided encoding function.
+/// - `EncodeLike`: Trait indicating the type can be encoded as is.
+/// - `Decode`: Decodes the wrapper type from the input.
+/// - `TypeInfo`: Provides type information for the wrapper type.
+macro_rules! impl_codec_bitflags {
+	($wrapper:ty, $size:ty, $bitflag_enum:ty) => {
+		use parity_scale_codec::EncodeLike;
+		use scale_info::{build::Fields, meta_type, Path, Type, TypeParameter};
+
+		impl MaxEncodedLen for $wrapper {
+			fn max_encoded_len() -> usize {
+				<$size>::max_encoded_len()
+			}
+		}
+		impl Encode for $wrapper {
+			fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+				self.0.bits().using_encoded(f)
+			}
+		}
+		impl EncodeLike for $wrapper {}
+		impl Decode for $wrapper {
+			fn decode<I: parity_scale_codec::Input>(
+				input: &mut I,
+			) -> ::core::result::Result<Self, parity_scale_codec::Error> {
+				let field = <$size>::decode(input)?;
+				Ok(Self(BitFlags::from_bits(field as $size).map_err(|_| "invalid value")?))
+			}
+		}
+
+		impl TypeInfo for $wrapper {
+			type Identity = Self;
+
+			fn type_info() -> Type {
+				Type::builder()
+					.path(Path::new("BitFlags", module_path!()))
+					.type_params(vec![TypeParameter::new("T", Some(meta_type::<$bitflag_enum>()))])
+					.composite(
+						Fields::unnamed()
+							.field(|f| f.ty::<$size>().type_name(stringify!($bitflag_enum))),
+					)
+			}
+		}
+	};
+}
+pub(crate) use impl_codec_bitflags;

--- a/pallets/artists/src/migration.rs
+++ b/pallets/artists/src/migration.rs
@@ -1,0 +1,143 @@
+use super::*;
+use frame_support::{migrations::VersionedMigration, pallet_prelude::*, traits::OnRuntimeUpgrade};
+
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+pub mod versioned {
+	use super::*;
+
+	pub type V0ToV1<T> = VersionedMigration<
+		0,
+		1,
+		v1::VersionUncheckedMigrateV0ToV1<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>;
+}
+
+pub mod v1 {
+	use super::*;
+	use sp_runtime::Saturating;
+
+	/// The log target.
+	const TARGET: &'static str = "runtime::artists::migration::v1";
+
+	/// The old artist types, useful in pre-upgrade.
+	mod v0 {
+		use super::*;
+		use derive_getters::Getters;
+		use frame_support::pallet_prelude::{Decode, Encode, MaxEncodedLen, TypeInfo};
+		use frame_system::pallet_prelude::BlockNumberFor;
+		use sp_runtime::RuntimeDebug;
+
+		pub(super) type ArtistAliasOf<T> = BoundedVec<u8, <T as Config>::MaxNameLen>;
+
+		#[derive(
+			Encode, MaxEncodedLen, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, Getters,
+		)]
+		#[scale_info(skip_type_params(T))]
+		pub struct Artist<T>
+		where
+			T: frame_system::Config + Config,
+		{
+			// Main data
+			/// The artist's identifier. While the predominant mapping employs AccountId => Artist,
+			/// it's essential to include this in the artist's data since verified artists can be
+			/// retrieved by their name as well.
+			pub(super) owner: AccountIdOf<T>,
+			/// When the artist got registered on-chain.
+			pub(super) registered_at: BlockNumberFor<T>,
+			/// When the artist got verified.
+			verified_at: Option<BlockNumberFor<T>>,
+			// Metadata
+			/// The name of the artist.
+			/// This is generally the main name of how we usually call the artist (e.g: 'The
+			/// Weeknd') This is fixed and can't be changed after the registration.
+			pub(super) main_name: BoundedVec<u8, T::MaxNameLen>,
+			/// An alias to the main name.
+			/// This name can be changed compared to the 'nickname'
+			alias: Option<ArtistAliasOf<T>>,
+			/// The main music genres of the artists.
+			pub(super) genres: BoundedVec<MusicGenre, T::MaxGenres>,
+			// Metadata Fingerprint
+			// Given the significant size of certain data associated with an artist,
+			// we choose to store a digital fingerprint (hash) of this data rather than
+			// the raw data itself. This fingerprint acts as a unique digital reference,
+			// and services can use it to compare and validate the artist's data, ensuring
+			// that it has been approved and recorded on the blockchain by the artist themselves.
+			/// The digital fingerprint (hash) of the artist's description.
+			pub(crate) description: Option<T::Hash>,
+			/// Digital assets (such as photos, profile pictures, banners, videos, etc.)
+			/// that officially represent the artist. These fingerprints allow for the
+			/// verification of the authenticity of these assets.
+			pub(super) assets: BoundedVec<T::Hash, T::MaxAssets>,
+			// Linked chain logic data
+			/// Associated smart-contracts deployed by dApps for the artist (e.g: royalties
+			/// contracts)
+			contracts: BoundedVec<AccountIdOf<T>, ConstU32<512>>,
+		}
+	}
+
+	impl<T: Config> From<v0::Artist<T>> for Artist<T> {
+		fn from(value: v0::Artist<T>) -> Self {
+			Self {
+				owner: value.owner,
+				registered_at: value.registered_at,
+				main_name: value.main_name,
+				main_type: Default::default(),
+				extra_types: Default::default(),
+				genres: value.genres,
+				description: value.description,
+				assets: value.assets,
+			}
+		}
+	}
+
+	/// Migration to V1 Artist struct.
+	/// - Removing contracts, alias and verification.
+	/// - Adding artist types.
+	pub struct VersionUncheckedMigrateV0ToV1<T>(PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for VersionUncheckedMigrateV0ToV1<T> {
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			let artists = v0::ArtistOf::<T>::iter().count();
+			log::info!(
+				target: TARGET,
+				"pre-upgrade state contains '{}' artists.",
+				artists
+			);
+			Ok((artists as u64).encode())
+		}
+
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(
+				target: TARGET,
+				"running storage migration from version 0 to version 1."
+			);
+
+			let mut translated: u64 = 0;
+
+			ArtistOf::<T>::translate::<v0::Artist<T>, _>(|_key, old_artist| {
+				translated.saturating_inc();
+				Some(old_artist.into())
+			});
+			StorageVersion::new(1).put::<Pallet<T>>();
+
+			log::info!(target: TARGET, "all {} artists migrated", translated);
+
+			T::DbWeight::get().reads_writes(translated + 1, translated + 1)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			let artists_to_migrate: u64 = Decode::decode(&mut &state[..])
+				.expect("failed to decode the state from pre-upgrade.");
+			let artists = ArtistOf::<T>::iter().count() as u64;
+			log::info!("post-upgrade expects '{}' artists to have been migrated.", artists);
+			ensure!(artists_to_migrate == artists, "must migrate all artists.");
+			log::info!(target: TARGET, "migrated all artists.");
+			Ok(())
+		}
+	}
+}

--- a/pallets/artists/src/mock.rs
+++ b/pallets/artists/src/mock.rs
@@ -1,114 +1,115 @@
 // This file is part of Allfeat.
 
-// Copyright (C) Allfeat (FR) Ltd.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022-2024 Allfeat.
+// SPDX-License-Identifier: GPL-3.0-or-later
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! # Artists test environment.
 
 use super::*;
 use crate as pallet_artists;
-use frame_support::derive_impl;
-use frame_support::traits::{ConstU128, ConstU16, ConstU32, ConstU64};
-use frame_support::{parameter_types, PalletId};
+use frame_support::{
+	derive_impl, parameter_types,
+	traits::{ConstU128, ConstU16, ConstU32, ConstU64},
+};
 use frame_system::EnsureRoot;
-use sp_runtime::testing::H256;
-use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
-use sp_runtime::BuildStorage;
+use sp_runtime::{
+	testing::H256,
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
-    pub enum Test
-    {
-        System: frame_system,
-        Balances: pallet_balances,
-        Artists: pallet_artists,
-    }
+	pub enum Test
+	{
+		System: frame_system,
+		Balances: pallet_balances,
+		Artists: pallet_artists,
+	}
 );
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-    type BaseCallFilter = frame_support::traits::Everything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type DbWeight = ();
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeCall = RuntimeCall;
-    type Nonce = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = u64;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Block = Block;
-    type RuntimeEvent = RuntimeEvent;
-    type BlockHashCount = ConstU64<250>;
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = pallet_balances::AccountData<u128>;
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ConstU16<42>;
-    type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u128>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 impl pallet_balances::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = ();
-    type Balance = u128;
-    type DustRemoval = ();
-    type ExistentialDeposit = ConstU128<1>;
-    type AccountStore = System;
-    type ReserveIdentifier = [u8; 8];
-    type RuntimeHoldReason = RuntimeHoldReason;
-    type RuntimeFreezeReason = RuntimeFreezeReason;
-    type FreezeIdentifier = ();
-    type MaxLocks = ();
-    type MaxReserves = ();
-    type MaxFreezes = ();
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type Balance = u128;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU128<1>;
+	type AccountStore = System;
+	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type FreezeIdentifier = ();
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type MaxFreezes = ();
 }
 
 parameter_types! {
-    pub const ArtistsPalletId: PalletId = PalletId(*b"py/artst");
+	pub const ArtistsPalletId: PalletId = PalletId(*b"py/artst");
 }
 
 impl Config for Test {
-    type PalletId = ArtistsPalletId;
-    type RuntimeEvent = RuntimeEvent;
-    type Currency = Balances;
-    type BaseDeposit = ConstU128<5>;
-    type ByteDeposit = ConstU128<1>;
-    type RuntimeHoldReason = RuntimeHoldReason;
-    type RootOrigin = EnsureRoot<Self::AccountId>;
-    type Slash = ();
-    type UnregisterPeriod = ConstU32<10>;
-    type MaxNameLen = ConstU32<64>;
-    type MaxGenres = ConstU32<5>;
-    type MaxAssets = ConstU32<32>;
-    type MaxContracts = ConstU32<2048>;
-    type WeightInfo = ();
+	type PalletId = ArtistsPalletId;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type BaseDeposit = ConstU128<5>;
+	type ByteDeposit = ConstU128<1>;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RootOrigin = EnsureRoot<Self::AccountId>;
+	type Slash = ();
+	type UnregisterPeriod = ConstU32<10>;
+	type MaxNameLen = ConstU32<64>;
+	type MaxGenres = ConstU32<5>;
+	type MaxAssets = ConstU32<32>;
+	type WeightInfo = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    let mut t = frame_system::GenesisConfig::<Test>::default()
-        .build_storage()
-        .unwrap();
-    let balances = pallet_balances::GenesisConfig::<Test> {
-        balances: vec![(1, 500), (2, 500), (3, 500), (4, 500), (5, 500)],
-    };
-    balances.assimilate_storage(&mut t).unwrap();
-    t.into()
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let balances = pallet_balances::GenesisConfig::<Test> {
+		balances: vec![(1, 500), (2, 500), (3, 500), (4, 500), (5, 500)],
+	};
+	balances.assimilate_storage(&mut t).unwrap();
+	t.into()
 }

--- a/pallets/artists/src/tests.rs
+++ b/pallets/artists/src/tests.rs
@@ -1,19 +1,20 @@
 // This file is part of Allfeat.
 
-// Copyright (C) Allfeat (FR) Ltd.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022-2024 Allfeat.
+// SPDX-License-Identifier: GPL-3.0-or-later
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! # Artists tests.
 
@@ -22,34 +23,35 @@
 use super::*;
 use crate::{
 	mock::*,
-	types::{ArtistAliasOf, UpdatableData},
+	types::{ArtistType, ExtraArtistTypes},
 	Error as ArtistsError,
 };
-use frame_support::{assert_noop, assert_ok, pallet_prelude::Get};
+use frame_support::{assert_noop, assert_ok};
 use genres_registry::ElectronicSubtype;
 use parity_scale_codec::{Encode, MaxEncodedLen};
 use sp_runtime::{DispatchError::BadOrigin, Saturating};
-use sp_std::prelude::Vec;
 
 struct ArtistMock<T: Config> {
 	pub main_name: BoundedVec<u8, <T as Config>::MaxNameLen>,
-	pub alias: Option<BoundedVec<u8, <T as Config>::MaxNameLen>>,
+	pub main_type: ArtistType,
+	pub extra_types: ExtraArtistTypes,
 	pub genres: BoundedVec<MusicGenre, T::MaxGenres>,
 	pub description: Option<Vec<u8>>,
 	pub assets: BoundedVec<Vec<u8>, T::MaxAssets>,
 }
 
-fn to_bounded_alias(str: String) -> ArtistAliasOf<Test> {
-	ArtistAliasOf::<Test>::try_from(str.as_bytes().to_vec()).expect("invalid alias test string")
-}
-
 fn tester_artist<T: Config>() -> ArtistMock<T> {
+	let mut extra_types = ExtraArtistTypes::default();
 	let mut genres = Vec::new();
+
 	genres.push(MusicGenre::Electronic(Some(ElectronicSubtype::House)));
+	extra_types.0.insert(ArtistType::DiscJokey);
+	extra_types.0.insert(ArtistType::Instrumentalist);
 
 	ArtistMock {
 		main_name: b"Tester".to_vec().try_into().unwrap(),
-		alias: Some(b"Dark Singer".to_vec().try_into().unwrap()),
+		main_type: ArtistType::Singer,
+		extra_types,
 		genres: genres.try_into().unwrap(),
 		description: Some(b"A simple tester artist.".to_vec()),
 		assets: Default::default(),
@@ -60,12 +62,10 @@ fn expected_artist_cost<T: Config>(artist: &ArtistMock<T>) -> BalanceOf<T> {
 	let hash_size = T::Hash::max_encoded_len();
 
 	let name_size = artist.main_name.encoded_size();
-	let alias_size = artist.alias.encoded_size();
 
 	let hash_cost = T::ByteDeposit::get().saturating_mul(hash_size.saturated_into());
 
 	let name_cost = T::ByteDeposit::get().saturating_mul(name_size.saturated_into());
-	let alias_cost = T::ByteDeposit::get().saturating_mul(alias_size.saturated_into());
 	let description_cost = match artist.description {
 		Some(_) => hash_cost,
 		None => 0u32.saturated_into(),
@@ -77,7 +77,6 @@ fn expected_artist_cost<T: Config>(artist: &ArtistMock<T>) -> BalanceOf<T> {
 
 	T::BaseDeposit::get()
 		.saturating_add(name_cost)
-		.saturating_add(alias_cost)
 		.saturating_add(description_cost)
 		.saturating_add(assets_cost)
 }
@@ -93,7 +92,8 @@ fn artist_register_works() {
 		assert_ok!(Artists::register(
 			RuntimeOrigin::signed(artist_id),
 			artist.main_name.clone(),
-			artist.alias.clone(),
+			artist.main_type.clone(),
+			artist.extra_types.clone(),
 			artist.genres.clone(),
 			artist.description.clone(),
 			artist.assets.clone(),
@@ -111,7 +111,8 @@ fn artist_register_works() {
 			Artists::register(
 				RuntimeOrigin::signed(artist_id),
 				artist.main_name,
-				artist.alias,
+				artist.main_type,
+				artist.extra_types,
 				artist.genres,
 				artist.description,
 				artist.assets,
@@ -132,7 +133,8 @@ fn artist_force_unregister_works() {
 		assert_ok!(Artists::register(
 			RuntimeOrigin::signed(artist_id),
 			artist.main_name.clone(),
-			artist.alias.clone(),
+			artist.main_type.clone(),
+			artist.extra_types.clone(),
 			artist.genres.clone(),
 			artist.description.clone(),
 			artist.assets.clone(),
@@ -169,7 +171,8 @@ fn artist_unregister_works() {
 		assert_ok!(Artists::register(
 			RuntimeOrigin::signed(artist_id),
 			artist.main_name.clone(),
-			artist.alias.clone(),
+			artist.main_type.clone(),
+			artist.extra_types.clone(),
 			artist.genres.clone(),
 			artist.description.clone(),
 			artist.assets.clone(),
@@ -193,43 +196,5 @@ fn artist_unregister_works() {
 		let expected_cost = expected_artist_cost(&artist);
 
 		assert_eq!(new_balance, old_balance + expected_cost);
-	})
-}
-
-#[test]
-fn artist_update_alias_works() {
-	new_test_ext().execute_with(|| {
-		let artist = tester_artist::<Test>();
-		let artist_id = 1u64;
-
-		assert_ok!(Artists::register(
-			RuntimeOrigin::signed(artist_id),
-			artist.main_name.clone(),
-			artist.alias.clone(),
-			artist.genres.clone(),
-			artist.description.clone(),
-			artist.assets.clone(),
-		));
-
-		let new_alias = to_bounded_alias(String::from("new artist alias"));
-
-		assert_ok!(Artists::update(
-			RuntimeOrigin::signed(artist_id),
-			UpdatableData::<ArtistAliasOf<Test>>::Alias(Some(new_alias)),
-		));
-
-		// Can't update if the caller is not a registered artist
-		assert_noop!(
-			Artists::update(
-				RuntimeOrigin::signed(2),
-				UpdatableData::<ArtistAliasOf<Test>>::Alias(None),
-			),
-			Error::<Test>::NotRegistered
-		);
-
-		assert_ok!(Artists::update(
-			RuntimeOrigin::signed(artist_id),
-			UpdatableData::<ArtistAliasOf<Test>>::Alias(None),
-		));
 	})
 }

--- a/precompiles/artists/Artists.sol
+++ b/precompiles/artists/Artists.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 /// @dev The Artists contract's address.
-address constant ARTISTS_ADDRESS = 0x0000000000000000000000000000000000000803;
+address constant ARTISTS_ADDRESS = 0x0000000000000000000000000000000000000801;
 
 /// @dev The Artists contract's instance.
 Artists constant ARTISTS_CONTRACT = Artists(
@@ -14,31 +14,33 @@ Artists constant ARTISTS_CONTRACT = Artists(
 /// Addresses:
 /// - 0x0000000000000000000000000000000000000803: Artists
 interface Artists {
-    struct Verification {
-        bool is_verified;
-        uint32 verified_at;
-    }
-
-    struct Alias {
-        bool has_alias;
-        string _alias;
-    }
-
     struct DescriptionPreimage {
         bool has_preimage;
         bytes32 preimage;
     }
 
+    enum ArtistType {
+        Singer,
+        Instrumentalist,
+        Composer,
+        Lyricist,
+        Producer,
+        DiscJokey,
+        Conductor,
+        Arranger,
+        Engineer,
+        Director
+    }
+
     struct ArtistData {
         address owner;
         uint32 registered_at;
-        Verification verification;
+        ArtistType main_type;
+        ArtistType[] extra_types;
         string main_name;
-        Alias _alias;
         bytes[] genres;
         DescriptionPreimage description;
         bytes32[] assets;
-        address[] contracts;
     }
 
     struct Artist {

--- a/precompiles/artists/src/mock.rs
+++ b/precompiles/artists/src/mock.rs
@@ -198,7 +198,6 @@ impl pallet_artists::Config for Runtime {
 	type MaxNameLen = ConstU32<64>;
 	type MaxGenres = ConstU32<5>;
 	type MaxAssets = ConstU32<32>;
-	type MaxContracts = ConstU32<2048>;
 	type WeightInfo = ();
 }
 

--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 /// @dev The IERC20 contract's address.
-address constant IERC20_ADDRESS = 0x0000000000000000000000000000000000000802;
+address constant IERC20_ADDRESS = 0x0000000000000000000000000000000000000800;
 
 /// @dev The IERC20 contract's instance.
 IERC20 constant IERC20_CONTRACT = IERC20(IERC20_ADDRESS);
@@ -11,7 +11,7 @@ IERC20 constant IERC20_CONTRACT = IERC20(IERC20_ADDRESS);
  * @title ERC20 interface
  * @dev Interface of the ERC20 standard as defined in the EIP.
  * @dev copied from https://github.com/OpenZeppelin/openzeppelin-contracts
- * @custom:address 0x0000000000000000000000000000000000000802
+ * @custom:address 0x0000000000000000000000000000000000000800
  */
 interface IERC20 {
     /**

--- a/precompiles/nfts/collections/src/lib.rs
+++ b/precompiles/nfts/collections/src/lib.rs
@@ -140,8 +140,8 @@ where
 		// Storage item: Asset:
 		// Blake2_128(16) + CollectionId + CollectionDetails
 		handle.record_db_read::<Runtime>(
-			16 + CollectionIdOf::<Runtime>::max_encoded_len()
-				+ CollectionDetailsOf::<Runtime>::max_encoded_len(),
+			16 + CollectionIdOf::<Runtime>::max_encoded_len() +
+				CollectionDetailsOf::<Runtime>::max_encoded_len(),
 		)?;
 
 		let collection_details = pallet_nfts::Collection::<Runtime>::get(collection_id)

--- a/runtime/allfeat/src/lib.rs
+++ b/runtime/allfeat/src/lib.rs
@@ -1031,7 +1031,6 @@ parameter_types! {
 parameter_types! {
 	pub const MaxNameLen: u32 = 128;
 	pub const MaxGenres: u32 = 5;
-	pub const MaxContracts: u32 = 512;
 	pub const MaxAssets: u32 = 64;
 	pub const ByteDesposit: Balance = deposit(0, 1);
 	pub const BaseDeposit: Balance = 1 * AFT;
@@ -1051,7 +1050,6 @@ impl pallet_artists::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type MaxNameLen = MaxNameLen;
 	type MaxAssets = MaxAssets;
-	type MaxContracts = MaxContracts;
 	type MaxGenres = MaxGenres;
 	type WeightInfo = (); // TODO
 }

--- a/runtime/harmonie/src/pallets/artists.rs
+++ b/runtime/harmonie/src/pallets/artists.rs
@@ -23,7 +23,6 @@ use frame_system::EnsureRoot;
 parameter_types! {
 	pub const MaxNameLen: u32 = 128;
 	pub const MaxGenres: u32 = 5;
-	pub const MaxContracts: u32 = 512;
 	pub const MaxAssets: u32 = 64;
 	pub const ByteDesposit: Balance = deposit(0, 1);
 	pub const BaseDeposit: Balance = 1 * AFT;
@@ -43,7 +42,6 @@ impl pallet_artists::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type MaxNameLen = MaxNameLen;
 	type MaxAssets = MaxAssets;
-	type MaxContracts = MaxContracts;
 	type MaxGenres = MaxGenres;
 	type WeightInfo = weights::artists::AllfeatWeight<Runtime>;
 }


### PR DESCRIPTION
This PR aim to rework the Artist structure currently used.

The idea was to remove unused stuff that doesn't fit the design we aim for the moment and add new stuff that was asked by industry actors.

Changelog:
- Remove `contracts`, `alias` and `verified_at` of `Artist<T>`.
- Add a `main_type` and `extra_types` fields to `Artist<T>`.
- Add new `ArtistType` enum and `ExtraArtistTypes` BitFlag.
- Implement migration for v0 to v1.
- Update solidity contract interface and precompile to adapt to the changes.