### PR TITLE
ci: arm64 docker image support

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Set up Docker Buildx (required for advanced caching)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Set up Docker Buildx (required for advanced caching and multi-platform builds)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -64,6 +67,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Adds arm64 to the docker image builds so we get multi-platform images out of CI.

Changes:
- wire up QEMU and Buildx before the build step
- set `platforms: linux/amd64,linux/arm64` on the push action

Tested locally and via manual workflow dispatch on the branch, QEMU + Buildx steps both green.