### PR TITLE
fix lowercase image name in CI

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,24 +1,31 @@
 name: Build and Push Node Image
 
 on:
-  # This workflow is designed to be called by other "parent" workflows
   workflow_call:
-  # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: allfeat/allfeat
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
 
-    # Permissions required to push to GHCR
     permissions:
       contents: read
       packages: write
+
+    env:
+      IMAGE_NAME: ${{ github.repository_owner }}/allfeat
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Free Disk Space for Docker
@@ -27,19 +34,14 @@ jobs:
           remove_android: true
           remove_dotnet: true
           remove_haskell: true
-          rm_cmd: "rmz"  # Faster cleanup
+          rm_cmd: "rmz"
 
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      # Set up Docker Buildx (required for advanced caching and multi-platform builds)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login to GitHub Container Registry
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -47,11 +49,74 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # This handles the logic:
-      # - Pushing to master -> ghcr.io/org/repo:main
-      # - Pushing tag v1.0.0 -> ghcr.io/org/repo:1.0.0 AND :latest
-      # - Always adds sha-xxxx tag for precise K8s pinning
+      - name: Prepare platform slug
+        id: slug
+        run: echo "value=$(echo ${{ matrix.platform }} | tr '/' '-')" >> $GITHUB_OUTPUT
+
+      - name: Warm dependency cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          target: cacher
+          platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:buildcache-${{ steps.slug.outputs.value }}
+          cache-to: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:buildcache-${{ steps.slug.outputs.value }},mode=max
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:buildcache-${{ steps.slug.outputs.value }}
+          cache-to: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:buildcache-${{ steps.slug.outputs.value }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.slug.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      IMAGE_NAME: ${{ github.repository_owner }}/allfeat
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -63,16 +128,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
 
-      # Build and push Docker image
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Enable GitHub Actions caching for Docker layers
-          # This drastically speeds up Rust compilation by caching cargo dependencies
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -15,9 +15,6 @@ jobs:
       contents: read
       packages: write
 
-    env:
-      IMAGE_NAME: ${{ github.repository_owner }}/allfeat
-
     strategy:
       fail-fast: false
       matrix:
@@ -28,6 +25,9 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
+      - name: Set image name
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository_owner }}/allfeat' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Free Disk Space for Docker
         uses: endersonmenezes/free-disk-space@v3
         with:
@@ -96,10 +96,10 @@ jobs:
       contents: read
       packages: write
 
-    env:
-      IMAGE_NAME: ${{ github.repository_owner }}/allfeat
-
     steps:
+      - name: Set image name
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository_owner }}/allfeat' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,74 +2,63 @@
 # BASE #
 ########
 
-# base is the first stage where all the debian dependencies
-# needed to build the Allfeat binary are installed,
-# plus cargo-check to optimize rust dependency management and then speedup any re-build
-
-FROM rust:bookworm as base
+FROM rust:bookworm AS base
 
 WORKDIR /app
 
-# This installs all debian dependencies we need (besides Rust).
-RUN apt update -y && \
-    apt install -y build-essential git clang curl libssl-dev \
-    llvm libudev-dev make protobuf-compiler pkg-config libclang-dev
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      build-essential git clang curl libssl-dev \
+      llvm libudev-dev make protobuf-compiler pkg-config libclang-dev \
+      mold xz-utils && \
+    rm -rf /var/lib/apt/lists/*
 
-# Using cargo-chef to only pay the deps installation cost once,
-# it will be cached from the second build onwards
-RUN cargo install cargo-chef
+RUN ARCH=$(uname -m) && \
+    case "$ARCH" in \
+      x86_64)  TARGET="x86_64-unknown-linux-musl" ;; \
+      aarch64) TARGET="aarch64-unknown-linux-musl" ;; \
+      *) echo "unsupported arch: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -sSLf "https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.77/cargo-chef-${TARGET}.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin "cargo-chef-${TARGET}/cargo-chef"
+
+# cacher and builder must share the same linker or cargo treats the artifacts as stale
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 ###########
 # PLANNER #
 ###########
 
-# planner is where chef prepares its recipe using a local cache for the target
-
 FROM base AS planner
 COPY . .
 
-RUN --mount=type=cache,mode=0755,target=/app/target cargo chef prepare --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json
 
 ##########
 # CACHER #
 ##########
 
-# cacher is where chef cooks all the deps from the recipe inside the local cache
-
-FROM base as cacher
+FROM base AS cacher
 COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - this is the caching Docker layer!
 COPY --from=planner /app/rust-toolchain.toml rust-toolchain.toml
-RUN --mount=type=cache,mode=0755,target=/app/target cargo chef cook --release --recipe-path recipe.json
+
+RUN cargo chef cook --release --locked --recipe-path recipe.json
 
 ###########
 # BUILDER #
 ###########
 
-# builder is where chef builds the binary using the deps of the cache
-
 FROM cacher AS builder
 COPY . .
 
-# Build the binary
-# We prioritize the local toolchain file
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target \
-    cargo build --locked --release
+RUN cargo build --locked --release
 
-# Strip the binary to reduce the final image size significantly
-# (Removes debug symbols, not needed for production runtime)
-RUN --mount=type=cache,target=/app/target \
-    strip /app/target/release/allfeat && \
+RUN strip /app/target/release/allfeat && \
     cp /app/target/release/allfeat /usr/local/bin/allfeat
 
 ###########
 # RUNTIME #
 ###########
-
-# runtime is where the Allfeat binary is finally copied from the builder
-# inside an autonomous slim and secured image.
 
 FROM debian:bookworm-slim AS runtime
 
@@ -82,7 +71,6 @@ LABEL io.allfeat.image.type="builder" \
     io.allfeat.image.source="https://github.com/allfeat/allfeat/blob/${VCS_REF}/Dockerfile" \
     io.allfeat.image.documentation="https://github.com/allfeat/allfeat"
 
-# Install minimal runtime dependencies including shell
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
@@ -90,12 +78,10 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /usr/local/bin/allfeat /usr/local/bin
 
-
 RUN useradd -m -u 1000 -U -s /bin/sh -d /app allfeat && \
     mkdir -p /data /app/.local/share && \
     chown -R allfeat:allfeat /data && \
     ln -s /data /app/.local/share/allfeat && \
-    # check if executable works in this container
     /usr/local/bin/allfeat --version
 
 USER allfeat
@@ -103,6 +89,5 @@ USER allfeat
 EXPOSE 30333 9933 9944 9615
 
 VOLUME ["/data"]
-
 
 ENTRYPOINT ["/usr/local/bin/allfeat"]


### PR DESCRIPTION
Follow-up to #97 as the build was failing on the upstream CI due to`github.repository_owner` keeping the original casing (`Allfeat` with capital A), which breaks OCI registry refs. 
